### PR TITLE
implemented a parent-child relation between spec and impl

### DIFF
--- a/opendse-model/src/main/java/net/sf/opendse/model/Models.java
+++ b/opendse-model/src/main/java/net/sf/opendse/model/Models.java
@@ -41,8 +41,8 @@ import edu.uci.ics.jung.graph.util.Pair;
 public class Models {
 
 	/**
-	 * The {@code IsCommunicationPredicate} is a {@code Predicate} that returns true if the task implements the
-	 * {@link ICommunication} interface.
+	 * The {@code IsCommunicationPredicate} is a {@code Predicate} that returns true
+	 * if the task implements the {@link ICommunication} interface.
 	 * 
 	 * @author Martin Lukasiewycz
 	 * 
@@ -66,7 +66,8 @@ public class Models {
 	protected static IsCommunicationPredicate isCommunicationPredicate = new IsCommunicationPredicate();
 
 	/**
-	 * The {@code OnlyCommunicationIterator} is an iterator for tasks that only considers communication tasks.
+	 * The {@code OnlyCommunicationIterator} is an iterator for tasks that only
+	 * considers communication tasks.
 	 * 
 	 * @author Martin Lukasiewycz
 	 * 
@@ -90,8 +91,8 @@ public class Models {
 	protected static IsProcessPredicate isProcessPredicate = new IsProcessPredicate();
 
 	/**
-	 * The {@code IsCommunicationPredicate} is a {@code Predicate} that returns true if the task does not implement the
-	 * {@link ICommunication} interface.
+	 * The {@code IsCommunicationPredicate} is a {@code Predicate} that returns true
+	 * if the task does not implement the {@link ICommunication} interface.
 	 * 
 	 * @author Martin Lukasiewycz
 	 * 
@@ -110,7 +111,8 @@ public class Models {
 	}
 
 	/**
-	 * The {@code OnlyCommunicationIterator} is an iterator for tasks that only considers process tasks.
+	 * The {@code OnlyCommunicationIterator} is an iterator for tasks that only
+	 * considers process tasks.
 	 * 
 	 * @author Martin Lukasiewycz
 	 * 
@@ -129,7 +131,8 @@ public class Models {
 	}
 
 	/**
-	 * Filters an {@code Iterable} such that only communication tasks are considered.
+	 * Filters an {@code Iterable} such that only communication tasks are
+	 * considered.
 	 * 
 	 * @param iterable
 	 *            the iterable
@@ -183,8 +186,8 @@ public class Models {
 	}
 
 	/**
-	 * The {@code DirectedLink} is a {@link Link} wrapper that contains the source {@code Resource} and destination
-	 * {@code Resource}.
+	 * The {@code DirectedLink} is a {@link Link} wrapper that contains the source
+	 * {@code Resource} and destination {@code Resource}.
 	 * 
 	 * @author Martin Lukasiewycz
 	 * 
@@ -240,7 +243,8 @@ public class Models {
 	}
 
 	/**
-	 * Returns the list of {@code DirectedLink} elements that have a given source {code Resource}.
+	 * Returns the list of {@code DirectedLink} elements that have a given source
+	 * {code Resource}.
 	 * 
 	 * @param architecture
 	 *            the architecture
@@ -262,7 +266,8 @@ public class Models {
 	}
 
 	/**
-	 * Returns the list of {@code DirectedLink} elements that have a given destination {code Resource}.
+	 * Returns the list of {@code DirectedLink} elements that have a given
+	 * destination {code Resource}.
 	 * 
 	 * @param architecture
 	 *            the architecture
@@ -295,7 +300,8 @@ public class Models {
 	}
 
 	/**
-	 * Returns all {@code DirectedLink} elements of an {@code Architecture} for given {@code Link}.
+	 * Returns all {@code DirectedLink} elements of an {@code Architecture} for
+	 * given {@code Link}.
 	 * 
 	 * @param architecture
 	 *            the architecture
@@ -320,7 +326,8 @@ public class Models {
 	}
 
 	/**
-	 * Returns a map of all pairs of {@code ids} and the corresponding {@code Element} objects.
+	 * Returns a map of all pairs of {@code ids} and the corresponding
+	 * {@code Element} objects.
 	 * 
 	 * @param specification
 	 *            the specification
@@ -348,6 +355,11 @@ public class Models {
 		for (Mapping<Task, Resource> mapping : mappings) {
 			elements.put(mapping.getId(), mapping);
 		}
+		if (elements.containsKey(Specification.SPECIFICATION_ELEMENT_ID)) {
+			throw new IllegalStateException("Collision between specification id and the id of an the element "
+					+ elements.get(Specification.SPECIFICATION_ELEMENT_ID).toString());
+		}
+		elements.put(Specification.SPECIFICATION_ELEMENT_ID, specification);
 		return elements;
 	}
 
@@ -369,12 +381,13 @@ public class Models {
 		elements.addAll(architecture.getVertices());
 		elements.addAll(architecture.getEdges());
 		elements.addAll(mappings.getAll());
+		elements.add(specification);
 		return elements;
 	}
 
 	/**
-	 * Returns an {@link Iterable} which returns only those {@link Element}s from the given {@code iterable} which are
-	 * of one of the given {@code types}.
+	 * Returns an {@link Iterable} which returns only those {@link Element}s from
+	 * the given {@code iterable} which are of one of the given {@code types}.
 	 * 
 	 * @param <E>
 	 *            the type of the element
@@ -405,8 +418,8 @@ public class Models {
 	}
 
 	/**
-	 * Creates a copy of the given {@link Specification} using {@link #copy(Element)}, i.e., create new instances for
-	 * all {@link Element}s.
+	 * Creates a copy of the given {@link Specification} using
+	 * {@link #copy(Element)}, i.e., create new instances for all {@link Element}s.
 	 * 
 	 * @param specification
 	 * @return a copy of the specification
@@ -528,7 +541,8 @@ public class Models {
 	}
 
 	/**
-	 * Creates a clone of the {@link Specification}, i.e., with identical {@link Element}s ({@code ==}).
+	 * Creates a clone of the {@link Specification}, i.e., with identical
+	 * {@link Element}s ({@code ==}).
 	 * 
 	 * @param specification
 	 *            the specification to be cloned
@@ -555,7 +569,8 @@ public class Models {
 	}
 
 	/**
-	 * Creates a clone of the {@link Application}, i.e., with identical {@link Element}s ({@code ==}).
+	 * Creates a clone of the {@link Application}, i.e., with identical
+	 * {@link Element}s ({@code ==}).
 	 * 
 	 * @param sApplication
 	 *            the application to be cloned
@@ -579,7 +594,8 @@ public class Models {
 	}
 
 	/**
-	 * Creates a clone of the {@link Architecture}, i.e., with identical {@link Element}s ({@code ==}).
+	 * Creates a clone of the {@link Architecture}, i.e., with identical
+	 * {@link Element}s ({@code ==}).
 	 * 
 	 * @param sArchitecture
 	 *            the architecture to be cloned

--- a/opendse-model/src/main/java/net/sf/opendse/model/Specification.java
+++ b/opendse-model/src/main/java/net/sf/opendse/model/Specification.java
@@ -32,8 +32,11 @@ import net.sf.opendse.model.parameter.Parameter;
  * @author Martin Lukasiewycz
  * 
  */
-public class Specification implements IAttributes {
+public class Specification extends Element {
 
+	// the unique id of the specification element; no other element must have this id
+	public static final String SPECIFICATION_ELEMENT_ID = "specificationElementId";
+	
 	protected Architecture<?, ?> architecture = null;
 	protected Application<?, ?> application = null;
 	protected Mappings<?, ?> mappings = null;
@@ -91,7 +94,7 @@ public class Specification implements IAttributes {
 	 */
 	public Specification(Application<?, ?> application, Architecture<?, ?> architecture, Mappings<?, ?> mappings,
 			Routings<?, ?, ?> routings) {
-		super();
+		super(SPECIFICATION_ELEMENT_ID);
 		this.architecture = architecture;
 		this.application = application;
 		this.mappings = mappings;

--- a/opendse-optimization/src/main/java/net/sf/opendse/optimization/encoding/Interpreter.java
+++ b/opendse-optimization/src/main/java/net/sf/opendse/optimization/encoding/Interpreter.java
@@ -203,7 +203,7 @@ public class Interpreter {
 		}
 
 		Specification impl = new Specification(iApplication, iArchitecture, iMappings, iRoutings);
-
+		impl.setParent(specification);
 		Map<String, Element> map = Models.getElementsMap(impl);
 
 		// set active parameters


### PR DESCRIPTION
Made the specification class extend 'Element' instead of only implementing 'IAttributes'. Each implementation now has a reference to the specification as its parent. This allows to (1) conveniently access the spec from the implementation (e.g. during the evaluation) and (2) to explore parameters per implementation by just setting a parameter as an attribute of the specification.