### PR TITLE
Fix for the spec reader bug which leads to errors when switching the specification.

### DIFF
--- a/opendse-optimization/src/main/java/net/sf/opendse/optimization/io/SpecificationWrapperFilename.java
+++ b/opendse-optimization/src/main/java/net/sf/opendse/optimization/io/SpecificationWrapperFilename.java
@@ -33,13 +33,11 @@ import com.google.inject.Inject;
 
 public class SpecificationWrapperFilename extends SpecificationWrapperInstance {
 
-	static SpecificationReader reader = new SpecificationReader();
-
 	@Inject
 	public SpecificationWrapperFilename(
 			@Constant(namespace = SpecificationWrapperFilename.class, value = "filename") String filename)
 			throws FileNotFoundException {
-		super(reader.read(new FileInputStream(filename)));
+		super(new SpecificationReader().read(new FileInputStream(filename)));
 	}
 
 	@Override


### PR DESCRIPTION
Deactivated the static use of a single SpecificationReader instance. 