### PR TITLE
provide Jacoco test report as .csv

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -147,7 +147,8 @@ task jacocoRootReport(type: org.gradle.testing.jacoco.tasks.JacocoReport) {
 		html.destination(file("${buildDir}/reports/jacoco"))
 		xml.enabled = true
 		xml.destination(file("${buildDir}/reports/jacoco/rootReport.xml"))
-		csv.enabled = false
+		csv.enabled = true
+		xml.destination(file("${buildDir}/reports/jacoco/rootReport.csv"))
 	}
 	onlyIf = {
 		true


### PR DESCRIPTION
To ease other integrations, providing the test report as .csv does - imho - not do any harm.